### PR TITLE
Wayland clipboard support via data_control protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ readme = "README.md"
 keywords = ["clipboard", "image"]
 edition = "2018"
 
+[features]
+default = ["x11"]
+x11 = ["x11rb"]
+wayland-data-control = ["wl-clipboard-rs"]
+
 [dependencies]
 thiserror = "1.0"
 
@@ -35,6 +40,7 @@ image = { version = "0.23", default-features = false, features = ["tiff"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 log = "0.4"
-x11rb = "0.8"
+x11rb = { version = "0.8", optional = true }
+wl-clipboard-rs = { version = "0.4.1", optional = true }
 lazy_static = "1.4.0"
 image = { version = "0.23.9", default-features = false, features = ["png"] }

--- a/src/common.rs
+++ b/src/common.rs
@@ -122,7 +122,8 @@ impl<'a> ImageData<'a> {
 	}
 }
 
-pub(crate) fn convert_to_png<'a>(image: ImageData<'a>) -> Result<ImageData<'a>, Error> {
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))]
+pub(crate) fn convert_to_png(image: ImageData) -> Result<ImageData, Error> {
 	/// This is a workaround for the PNGEncoder not having a `into_inner` like function
 	/// which would allow us to take back our Vec after the encoder finished encoding.
 	/// So instead we create this wrapper around an Rc Vec which implements `io::Write`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,19 @@ extern crate image;
 mod common;
 pub use common::{Error, ImageData};
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))]
+#[cfg(all(
+	unix,
+	not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
+	feature = "x11"
+))]
 pub mod x11_clipboard;
+
+#[cfg(all(
+	unix,
+	not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
+	feature = "wayland-data-control"
+))]
+pub mod wayland_data_control_clipboard;
 
 #[cfg(windows)]
 pub mod windows_clipboard;
@@ -30,8 +41,18 @@ pub mod windows_clipboard;
 #[cfg(target_os = "macos")]
 pub mod osx_clipboard;
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))]
+#[cfg(all(
+	unix,
+	not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
+	feature = "x11"
+))]
 type PlatformClipboard = x11_clipboard::X11ClipboardContext;
+#[cfg(all(
+	unix,
+	not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
+	feature = "wayland-data-control"
+))]
+type PlatformClipboard = wayland_data_control_clipboard::WaylandDataControlClipboardContext;
 #[cfg(windows)]
 type PlatformClipboard = windows_clipboard::WindowsClipboardContext;
 #[cfg(target_os = "macos")]

--- a/src/wayland_data_control_clipboard.rs
+++ b/src/wayland_data_control_clipboard.rs
@@ -40,7 +40,7 @@ impl WaylandDataControlClipboardContext {
 		use wl_clipboard_rs::copy::MimeType;
 		let opts = Options::new();
 		let source = Source::Bytes(text.as_bytes().into());
-		opts.copy(source, MimeType::Autodetect).map_err(map_copy_error)?;
+		opts.copy(source, MimeType::Text).map_err(into_unknown)?;
 		Ok(())
 	}
 
@@ -120,13 +120,13 @@ impl WaylandDataControlClipboardContext {
 		if encoding_result.is_ok() {
 			let opts = Options::new();
 			let source = Source::Bytes(Rc::try_unwrap(buffer.inner).unwrap().into_inner().into());
-			opts.copy(source, MimeType::Autodetect).map_err(map_copy_error)?;
+			opts.copy(source, MimeType::Specific("image/png".into())).map_err(into_unknown)?;
 		}
 
 		Ok(())
 	}
 }
 
-fn map_copy_error(error: wl_clipboard_rs::copy::Error) -> Error {
+fn into_unknown(error: wl_clipboard_rs::copy::Error) -> Error {
 	Error::Unknown { description: format!("{}", error) }
 }

--- a/src/wayland_data_control_clipboard.rs
+++ b/src/wayland_data_control_clipboard.rs
@@ -12,6 +12,7 @@ use wl_clipboard_rs::paste::{get_contents, ClipboardType, Error as PasteError, S
 pub struct WaylandDataControlClipboardContext {}
 
 impl WaylandDataControlClipboardContext {
+	#[allow(clippy::unnecessary_wraps)]
 	pub(crate) fn new() -> Result<Self, Error> {
 		Ok(Self {})
 	}
@@ -31,7 +32,7 @@ impl WaylandDataControlClipboardContext {
 				Err(Error::ContentNotAvailable)
 			}
 
-			Err(err) => Err(Error::Unknown { description: format!("{}", err) })?,
+			Err(err) => return Err(Error::Unknown { description: format!("{}", err) }),
 		}
 	}
 
@@ -74,7 +75,7 @@ impl WaylandDataControlClipboardContext {
 				Err(Error::ContentNotAvailable)
 			}
 
-			Err(err) => Err(Error::Unknown { description: format!("{}", err) })?,
+			Err(err) => return Err(Error::Unknown { description: format!("{}", err) }),
 		}
 	}
 

--- a/src/wayland_data_control_clipboard.rs
+++ b/src/wayland_data_control_clipboard.rs
@@ -1,0 +1,131 @@
+use super::common::{Error, ImageData};
+
+use std::{
+	cell::RefCell,
+	io::{Cursor, Read},
+	rc::Rc,
+};
+
+use wl_clipboard_rs::copy::{Options, Source};
+use wl_clipboard_rs::paste::{get_contents, ClipboardType, Error as PasteError, Seat};
+
+pub struct WaylandDataControlClipboardContext {}
+
+impl WaylandDataControlClipboardContext {
+	pub(crate) fn new() -> Result<Self, Error> {
+		Ok(Self {})
+	}
+
+	pub fn get_text(&mut self) -> Result<String, Error> {
+		use wl_clipboard_rs::paste::MimeType;
+		let result = get_contents(ClipboardType::Regular, Seat::Unspecified, MimeType::Text);
+		match result {
+			Ok((mut pipe, _)) => {
+				let mut contents = vec![];
+				pipe.read_to_end(&mut contents)
+					.map_err(|e| Error::Unknown { description: format!("{}", e) })?;
+				String::from_utf8(contents).map_err(|_| Error::ConversionFailure)
+			}
+
+			Err(PasteError::ClipboardEmpty) | Err(PasteError::NoMimeType) => {
+				Err(Error::ContentNotAvailable)
+			}
+
+			Err(err) => Err(Error::Unknown { description: format!("{}", err) })?,
+		}
+	}
+
+	pub fn set_text(&mut self, text: String) -> Result<(), Error> {
+		use wl_clipboard_rs::copy::MimeType;
+		let opts = Options::new();
+		let source = Source::Bytes(text.as_bytes().into());
+		opts.copy(source, MimeType::Autodetect).map_err(map_copy_error)?;
+		Ok(())
+	}
+
+	pub fn get_image(&mut self) -> Result<ImageData, Error> {
+		use wl_clipboard_rs::paste::MimeType;
+		let result = get_contents(ClipboardType::Regular, Seat::Unspecified, MimeType::Any);
+		match result {
+			//TODO: Use mime_type to select Reader format
+			Ok((mut pipe, _mime_type)) => {
+				let mut buffer = vec![];
+				pipe.read_to_end(&mut buffer)
+					.map_err(|e| Error::Unknown { description: format!("{}", e) })?;
+				dbg!(&buffer);
+				let image = image::io::Reader::new(Cursor::new(buffer))
+					.with_guessed_format()
+					.map_err(|_| Error::ConversionFailure)?
+					.decode()
+					.map_err(|e| {
+						dbg!(e);
+						Error::ConversionFailure
+					})?;
+				let image = image.into_rgba8();
+
+				Ok(ImageData {
+					width: image.width() as usize,
+					height: image.height() as usize,
+					bytes: image.into_raw().into(),
+				})
+			}
+
+			Err(PasteError::ClipboardEmpty) | Err(PasteError::NoMimeType) => {
+				Err(Error::ContentNotAvailable)
+			}
+
+			Err(err) => Err(Error::Unknown { description: format!("{}", err) })?,
+		}
+	}
+
+	pub fn set_image(&mut self, image: ImageData) -> Result<(), Error> {
+		use wl_clipboard_rs::copy::MimeType;
+
+		/// This is a workaround for the PNGEncoder not having a `into_inner` like function
+		/// which would allow us to take back our Vec after the encoder finished encoding.
+		/// So instead we create this wrapper around an Rc Vec which implements `io::Write`
+		#[derive(Clone)]
+		struct RcBuffer {
+			inner: Rc<RefCell<Vec<u8>>>,
+		}
+		impl std::io::Write for RcBuffer {
+			fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+				self.inner.borrow_mut().extend_from_slice(buf);
+				Ok(buf.len())
+			}
+			fn flush(&mut self) -> std::io::Result<()> {
+				// Noop
+				Ok(())
+			}
+		}
+
+		if image.bytes.is_empty() || image.width == 0 || image.height == 0 {
+			return Err(Error::ConversionFailure);
+		}
+
+		let buffer = RcBuffer { inner: Rc::new(RefCell::new(Vec::new())) };
+		let encoding_result;
+		{
+			let encoder = image::png::PngEncoder::new(buffer.clone());
+			encoding_result = encoder.encode(
+				image.bytes.as_ref(),
+				image.width as u32,
+				image.height as u32,
+				image::ColorType::Rgba8,
+			);
+		}
+		// Rust impl: The encoder must be destroyed so that it lets go of its reference to the
+		// `output` before we `try_unwrap()`
+		if encoding_result.is_ok() {
+			let opts = Options::new();
+			let source = Source::Bytes(Rc::try_unwrap(buffer.inner).unwrap().into_inner().into());
+			opts.copy(source, MimeType::Autodetect).map_err(map_copy_error)?;
+		}
+
+		Ok(())
+	}
+}
+
+fn map_copy_error(error: wl_clipboard_rs::copy::Error) -> Error {
+	Error::Unknown { description: format!("{}", error) }
+}

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -970,9 +970,8 @@ fn encode_data_on_demand(
 	buffer: &mut Option<Arc<Mutex<Vec<u8>>>>,
 ) {
 	if atom == shared.common_atoms().MIME_IMAGE_PNG {
-		let _ = convert_to_png(image.to_owned_img()).and_then(|image| {
+		let _ = convert_to_png(image.to_owned_img()).map(|image| {
 			*buffer = Some(Arc::new(Mutex::new(image.bytes.into())));
-			Ok(())
 		});
 	}
 }

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -32,9 +32,7 @@ and conditions of the chosen license apply to this file.
 //!
 //!
 
-use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -53,6 +51,8 @@ use x11rb::{
 	rust_connection::RustConnection,
 	wrapper::ConnectionExt as _,
 };
+
+use crate::common::convert_to_png;
 
 use super::common::{Error, ImageData};
 
@@ -969,46 +969,11 @@ fn encode_data_on_demand(
 	atom: xproto::Atom,
 	buffer: &mut Option<Arc<Mutex<Vec<u8>>>>,
 ) {
-	/// This is a workaround for the PNGEncoder not having a `into_inner` like function
-	/// which would allow us to take back our Vec after the encoder finished encoding.
-	/// So instead we create this wrapper around an Rc Vec which implements `io::Write`
-	#[derive(Clone)]
-	struct RcBuffer {
-		inner: Rc<RefCell<Vec<u8>>>,
-	}
-	impl std::io::Write for RcBuffer {
-		fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-			self.inner.borrow_mut().extend_from_slice(buf);
-			Ok(buf.len())
-		}
-		fn flush(&mut self) -> std::io::Result<()> {
-			// Noop
-			Ok(())
-		}
-	}
-
 	if atom == shared.common_atoms().MIME_IMAGE_PNG {
-		if image.bytes.is_empty() || image.width == 0 || image.height == 0 {
-			return;
-		}
-
-		let output = RcBuffer { inner: Rc::new(RefCell::new(Vec::new())) };
-		let encoding_result;
-		{
-			let encoder = image::png::PngEncoder::new(output.clone());
-			encoding_result = encoder.encode(
-				image.bytes.as_ref(),
-				image.width as u32,
-				image.height as u32,
-				image::ColorType::Rgba8,
-			);
-		}
-		// Rust impl: The encoder must be destroyed so that it lets go of its reference to the
-		// `output` before we `try_unwrap()`
-		if encoding_result.is_ok() {
-			*buffer =
-				Some(Arc::new(Mutex::new(Rc::try_unwrap(output.inner).unwrap().into_inner())));
-		}
+		let _ = convert_to_png(image.to_owned_img()).and_then(|image| {
+			*buffer = Some(Arc::new(Mutex::new(image.bytes.into())));
+			Ok(())
+		});
 	}
 }
 


### PR DESCRIPTION
While it is true that wayland can support that X11 way of handling
clipboard support, this requires a running xwayland server and
compositor support for running xwayland.

This change introduces a new clipboard context
`WaylandDataControlClipboardContext` which is a wrapper around the
wl-clipboard-rs crate. This crate handles all of the communication with
the compositor for us.

To selected between X11 and wayland data_control clipboard handle is not
possible via a platform selector, as is the case for windows and mac,
two new features where add `x11` and `wayland-data-control`. The `x11`
feature is in the `default` feature set as to preserve backward
compatibility.

The feature name `wayland-data-control` was chosen to handle other
possible wayland protocols to interface with a clipboard.

Looking forward to your review :)