### PR TITLE
Support selecting which linux clipboard we operate on.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -24,6 +24,14 @@ pub enum Error {
 	#[error("The clipboard contents were not available in the requested format or the clipboard is empty.")]
 	ContentNotAvailable,
 
+	/// The selected clipboard is not supported by the current configuration (system and/or environment).
+	///
+	/// This can be caused by a few conditions:
+	/// - Using the Primary clipboard with an older Wayland compositor (that doesn't support version 2)
+	/// - Using the Secondary clipboard on Wayland
+	#[error("The selected clipboard is not supported with the current system configuration.")]
+	ClipboardNotSupported,
+
 	/// The native clipboard is not accessible due to being held by an other party.
 	///
 	/// This "other party" could be a different process or it could be within
@@ -64,8 +72,13 @@ impl std::fmt::Debug for Error {
 				}
 			}
 		}
-		let name =
-			kind_to_str!(ContentNotAvailable, ClipboardOccupied, ConversionFailure, Unknown { .. });
+		let name = kind_to_str!(
+			ContentNotAvailable,
+			ClipboardNotSupported,
+			ClipboardOccupied,
+			ConversionFailure,
+			Unknown { .. }
+		);
 		f.write_fmt(format_args!("{} - \"{}\"", name, self))
 	}
 }

--- a/src/common_linux.rs
+++ b/src/common_linux.rs
@@ -55,7 +55,7 @@ pub fn encode_as_png(image: &ImageData) -> Result<Vec<u8>, Error> {
 /// Clipboard selection
 #[derive(Copy, Clone, Debug)]
 pub enum LinuxClipboardKind {
-	/// Typically used selection for explicit cut/copy/past actions (ie. windows/macos like
+	/// Typically used selection for explicit cut/copy/paste actions (ie. windows/macos like
 	/// clipboard behavior)
 	Clipboard,
 

--- a/src/wayland_data_control_clipboard.rs
+++ b/src/wayland_data_control_clipboard.rs
@@ -1,19 +1,50 @@
-use std::io::{Cursor, Read};
+use std::{
+	convert::TryInto,
+	io::{Cursor, Read},
+};
 
 use wl_clipboard_rs::{
-	copy::{Options, Source},
-	paste::{get_contents, ClipboardType, Error as PasteError, Seat},
+	copy::{self, Options, Source},
+	paste::{self, get_contents, Error as PasteError, Seat},
 	utils::is_primary_selection_supported,
 };
 
 use crate::{
 	common::{Error, ImageData},
-	common_linux::{encode_as_png, into_unknown},
+	common_linux::{encode_as_png, into_unknown, LinuxClipboardKind},
 };
 
 static MIME_PNG: &str = "image/png";
 
 pub struct WaylandDataControlClipboardContext {}
+
+impl TryInto<copy::ClipboardType> for LinuxClipboardKind {
+	type Error = Error;
+
+	fn try_into(self) -> Result<copy::ClipboardType, Self::Error> {
+		match self {
+			LinuxClipboardKind::Clipboard => Ok(copy::ClipboardType::Regular),
+			LinuxClipboardKind::Primary => Ok(copy::ClipboardType::Primary),
+			LinuxClipboardKind::Secondary => {
+				return Err(Error::ContentNotAvailable);
+			}
+		}
+	}
+}
+
+impl TryInto<paste::ClipboardType> for LinuxClipboardKind {
+	type Error = Error;
+
+	fn try_into(self) -> Result<paste::ClipboardType, Self::Error> {
+		match self {
+			LinuxClipboardKind::Clipboard => Ok(paste::ClipboardType::Regular),
+			LinuxClipboardKind::Primary => Ok(paste::ClipboardType::Primary),
+			LinuxClipboardKind::Secondary => {
+				return Err(Error::ContentNotAvailable);
+			}
+		}
+	}
+}
 
 impl WaylandDataControlClipboardContext {
 	#[allow(clippy::unnecessary_wraps)]
@@ -26,8 +57,16 @@ impl WaylandDataControlClipboardContext {
 	}
 
 	pub fn get_text(&mut self) -> Result<String, Error> {
+		self.get_text_with_clipboard(LinuxClipboardKind::Clipboard)
+	}
+
+	pub(crate) fn get_text_with_clipboard(
+		&mut self,
+		selection: LinuxClipboardKind,
+	) -> Result<String, Error> {
 		use wl_clipboard_rs::paste::MimeType;
-		let result = get_contents(ClipboardType::Regular, Seat::Unspecified, MimeType::Text);
+
+		let result = get_contents(selection.try_into()?, Seat::Unspecified, MimeType::Text);
 		match result {
 			Ok((mut pipe, _)) => {
 				let mut contents = vec![];
@@ -35,23 +74,33 @@ impl WaylandDataControlClipboardContext {
 				String::from_utf8(contents).map_err(|_| Error::ConversionFailure)
 			}
 
-			Err(PasteError::ClipboardEmpty) | Err(PasteError::NoMimeType) => {
-				Err(Error::ContentNotAvailable)
-			}
+			Err(PasteError::ClipboardEmpty)
+			| Err(PasteError::NoMimeType)
+			| Err(PasteError::PrimarySelectionUnsupported) => Err(Error::ContentNotAvailable),
 
 			Err(err) => return Err(Error::Unknown { description: format!("{}", err) }),
 		}
 	}
 
 	pub fn set_text(&mut self, text: String) -> Result<(), Error> {
+		self.set_text_with_clipboard(text, LinuxClipboardKind::Clipboard)
+	}
+
+	pub(crate) fn set_text_with_clipboard(
+		&self,
+		text: String,
+		selection: LinuxClipboardKind,
+	) -> Result<(), Error> {
 		use wl_clipboard_rs::copy::MimeType;
-		let opts = Options::new();
+		let mut opts = Options::new();
+		opts.clipboard(selection.try_into()?);
 		let source = Source::Bytes(text.as_bytes().into());
 		opts.copy(source, MimeType::Text).map_err(into_unknown)?;
 		Ok(())
 	}
 
 	pub fn get_image(&mut self) -> Result<ImageData, Error> {
+		use paste::ClipboardType;
 		use wl_clipboard_rs::paste::MimeType;
 		let result =
 			get_contents(ClipboardType::Regular, Seat::Unspecified, MimeType::Specific(MIME_PNG));

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -44,7 +44,7 @@ use x11rb::{
 };
 
 use crate::{
-	common_linux::{encode_as_png, into_unknown},
+	common_linux::{encode_as_png, into_unknown, LinuxClipboardKind},
 	Error, ImageData,
 };
 
@@ -55,6 +55,9 @@ static CLIPBOARD: Lazy<Mutex<Option<GlobalClipboard>>> = Lazy::new(|| Mutex::new
 x11rb::atom_manager! {
 	pub Atoms: AtomCookies {
 		CLIPBOARD,
+		PRIMARY,
+		SECONDARY,
+
 		CLIPBOARD_MANAGER,
 		SAVE_TARGETS,
 		TARGETS,
@@ -113,7 +116,10 @@ struct ClipboardContext {
 	/// requests coming to us.
 	server: XContext,
 	atoms: Atoms,
-	data: RwLock<Option<ClipboardData>>,
+	clipboard_data: RwLock<Option<ClipboardData>>,
+	primary_data: RwLock<Option<ClipboardData>>,
+	secondary_data: RwLock<Option<ClipboardData>>,
+
 	handover_state: Mutex<ManagerHandoverState>,
 	handover_cv: Condvar,
 
@@ -184,33 +190,35 @@ impl ClipboardContext {
 		Ok(Self {
 			server,
 			atoms,
-			data: RwLock::default(),
+			clipboard_data: RwLock::default(),
+			primary_data: RwLock::default(),
+			secondary_data: RwLock::default(),
 			handover_state: Mutex::new(ManagerHandoverState::Idle),
 			handover_cv: Condvar::new(),
 			serve_stopped: AtomicBool::new(false),
 		})
 	}
 
-	fn write(&self, data: ClipboardData) -> Result<()> {
+	fn write(&self, data: ClipboardData, selection: LinuxClipboardKind) -> Result<()> {
 		if self.serve_stopped.load(Ordering::Relaxed) {
 			return Err(Error::Unknown {
                 description: "The clipboard handler thread seems to have stopped. Logging messages may reveal the cause. (See the `log` crate.)".into()
             });
 		}
+
 		// only if the current owner isn't us, we try to become it
-		if !self.is_owner()? {
-			let selection = self.atoms.CLIPBOARD;
+		if !self.is_owner(selection)? {
 			let server_win = self.server.win_id;
 
 			self.server
 				.conn
-				.set_selection_owner(server_win, selection, Time::CURRENT_TIME)
+				.set_selection_owner(server_win, self.atom_of(selection), Time::CURRENT_TIME)
 				.map_err(|_| Error::ClipboardOccupied)?;
 			self.server.conn.flush().map_err(into_unknown)?;
 		}
 
 		// Just setting the data, and the `serve_requests` will take care of the rest.
-		*self.data.write() = Some(data);
+		*self.data_of(selection).write() = Some(data);
 
 		Ok(())
 	}
@@ -218,10 +226,10 @@ impl ClipboardContext {
 	/// `formats` must be a slice of atoms, where each atom represents a target format.
 	/// The first format from `formats`, which the clipboard owner supports will be the
 	/// format of the return value.
-	fn read(&self, formats: &[Atom]) -> Result<ClipboardData> {
+	fn read(&self, formats: &[Atom], selection: LinuxClipboardKind) -> Result<ClipboardData> {
 		// if we are the current owner, we can get the current clipboard ourselves
-		if self.is_owner()? {
-			let data = self.data.read();
+		if self.is_owner(selection)? {
+			let data = self.data_of(selection).read();
 			if let Some(data) = &*data {
 				for format in formats {
 					if *format == data.format {
@@ -238,7 +246,7 @@ impl ClipboardContext {
 
 		trace!("Trying to get the clipboard data.");
 		for format in formats {
-			match self.read_single(&reader, *format) {
+			match self.read_single(&reader, selection, *format) {
 				Ok(bytes) => {
 					return Ok(ClipboardData { bytes, format: *format });
 				}
@@ -251,7 +259,12 @@ impl ClipboardContext {
 		Err(Error::ContentNotAvailable)
 	}
 
-	fn read_single(&self, reader: &XContext, target_format: Atom) -> Result<Vec<u8>> {
+	fn read_single(
+		&self,
+		reader: &XContext,
+		selection: LinuxClipboardKind,
+		target_format: Atom,
+	) -> Result<Vec<u8>> {
 		// Delete the property so that we can detect (using property notify)
 		// when the selection owner receives our request.
 		reader
@@ -264,7 +277,7 @@ impl ClipboardContext {
 			.conn
 			.convert_selection(
 				reader.win_id,
-				self.atoms.CLIPBOARD,
+				self.atom_of(selection),
 				target_format,
 				self.atoms.ARBOARD_CLIPBOARD,
 				Time::CURRENT_TIME,
@@ -333,11 +346,36 @@ impl ClipboardContext {
 		Err(Error::ContentNotAvailable)
 	}
 
-	fn is_owner(&self) -> Result<bool> {
+	fn atom_of(&self, selection: LinuxClipboardKind) -> Atom {
+		match selection {
+			LinuxClipboardKind::Clipboard => self.atoms.CLIPBOARD,
+			LinuxClipboardKind::Primary => self.atoms.PRIMARY,
+			LinuxClipboardKind::Secondary => self.atoms.SECONDARY,
+		}
+	}
+
+	fn data_of(&self, selection: LinuxClipboardKind) -> &RwLock<Option<ClipboardData>> {
+		match selection {
+			LinuxClipboardKind::Clipboard => &self.clipboard_data,
+			LinuxClipboardKind::Primary => &self.primary_data,
+			LinuxClipboardKind::Secondary => &self.secondary_data,
+		}
+	}
+
+	fn kind_of(&self, atom: Atom) -> Option<LinuxClipboardKind> {
+		match atom {
+			a if a == self.atoms.CLIPBOARD => Some(LinuxClipboardKind::Clipboard),
+			a if a == self.atoms.PRIMARY => Some(LinuxClipboardKind::Primary),
+			a if a == self.atoms.SECONDARY => Some(LinuxClipboardKind::Secondary),
+			_ => None,
+		}
+	}
+
+	fn is_owner(&self, selection: LinuxClipboardKind) -> Result<bool> {
 		let current = self
 			.server
 			.conn
-			.get_selection_owner(self.atoms.CLIPBOARD)
+			.get_selection_owner(self.atom_of(selection))
 			.map_err(into_unknown)?
 			.reply()
 			.map_err(into_unknown)?
@@ -391,8 +429,8 @@ impl ClipboardContext {
 		if event.property == NONE || event.target != target_format {
 			return Err(Error::ContentNotAvailable);
 		}
-		if event.selection != self.atoms.CLIPBOARD {
-			log::info!("Received a SelectionNotify for a selection other than the `CLIPBOARD`. This is unexpected.");
+		if self.kind_of(event.selection).is_none() {
+			log::info!("Received a SelectionNotify for a selection other than CLIPBOARD, PRIMARY or SECONDARY. This is unexpected.");
 			return Ok(ReadSelNotifyResult::EventNotRecognized);
 		}
 		if *using_incr {
@@ -485,11 +523,14 @@ impl ClipboardContext {
 	}
 
 	fn handle_selection_request(&self, event: SelectionRequestEvent) -> Result<()> {
-		if event.selection != self.atoms.CLIPBOARD {
-			// We don't do anything here, this means that the
-			warn!("Received a selection request to a selection other than the CLIPBOARD. This is unexpected.");
-			return Ok(());
-		}
+		let selection = match self.kind_of(event.selection) {
+			Some(kind) => kind,
+			None => {
+				warn!("Received a selection request to a selection other than the CLIPBOARD, PRIMARY or SECONDARY. This is unexpected.");
+				return Ok(());
+			}
+		};
+
 		let success;
 		// we are asked for a list of supported conversion targets
 		if event.target == self.atoms.TARGETS {
@@ -497,7 +538,7 @@ impl ClipboardContext {
 			let mut targets = Vec::with_capacity(10);
 			targets.push(self.atoms.TARGETS);
 			targets.push(self.atoms.SAVE_TARGETS);
-			let data = self.data.read();
+			let data = self.data_of(selection).read();
 			if let Some(data) = &*data {
 				targets.push(data.format);
 				if data.format == self.atoms.UTF8_STRING {
@@ -522,7 +563,7 @@ impl ClipboardContext {
 			success = true;
 		} else {
 			trace!("Handling request for (probably) the clipboard contents.");
-			let data = self.data.read();
+			let data = self.data_of(selection).read();
 			if let Some(data) = &*data {
 				if data.format == event.target {
 					self.server
@@ -577,11 +618,12 @@ impl ClipboardContext {
 			error!("The server's window id was 0. This is unexpected");
 			return Ok(());
 		}
-		if !self.is_owner()? {
+
+		if !self.is_owner(LinuxClipboardKind::Clipboard)? {
 			// We are not owning the clipboard, nothing to do.
 			return Ok(());
 		}
-		if self.data.read().is_none() {
+		if self.data_of(LinuxClipboardKind::Clipboard).read().is_none() {
 			// If we don't have any data, there's nothing to do.
 			return Ok(());
 		}
@@ -676,9 +718,10 @@ fn serve_requests(clipboard: Arc<ClipboardContext>) -> Result<(), Box<dyn std::e
 				// Someone else has new content in the clipboard, so it is
 				// notifying us that we should delete our data now.
 				trace!("Somebody else owns the clipboard now");
-				if event.selection == clipboard.atoms.CLIPBOARD {
-					let mut data = clipboard.data.write();
-					*data = None;
+
+				if let Some(selection) = clipboard.kind_of(event.selection) {
+					let mut data = clipboard.data_of(selection).write();
+					*data = None
 				}
 			}
 			Event::SelectionRequest(event) => {
@@ -769,6 +812,10 @@ impl X11ClipboardContext {
 	}
 
 	pub fn get_text(&self) -> Result<String> {
+		self.get_text_with_clipboard(LinuxClipboardKind::Clipboard)
+	}
+
+	pub(crate) fn get_text_with_clipboard(&self, selection: LinuxClipboardKind) -> Result<String> {
 		let formats = [
 			self.inner.atoms.UTF8_STRING,
 			self.inner.atoms.UTF8_MIME_0,
@@ -777,7 +824,7 @@ impl X11ClipboardContext {
 			self.inner.atoms.TEXT,
 			self.inner.atoms.TEXT_MIME_UNKNOWN,
 		];
-		let result = self.inner.read(&formats)?;
+		let result = self.inner.read(&formats, selection)?;
 		if result.format == self.inner.atoms.STRING {
 			// ISO Latin-1
 			// See: https://stackoverflow.com/questions/28169745/what-are-the-options-to-convert-iso-8859-1-latin-1-to-a-string-utf-8
@@ -790,12 +837,22 @@ impl X11ClipboardContext {
 	pub fn set_text(&self, message: String) -> Result<()> {
 		let data =
 			ClipboardData { bytes: message.into_bytes(), format: self.inner.atoms.UTF8_STRING };
-		self.inner.write(data)
+		self.inner.write(data, LinuxClipboardKind::Clipboard)
+	}
+
+	pub(crate) fn set_text_with_clipboard(
+		&self,
+		message: String,
+		selection: LinuxClipboardKind,
+	) -> Result<()> {
+		let data =
+			ClipboardData { bytes: message.into_bytes(), format: self.inner.atoms.UTF8_STRING };
+		self.inner.write(data, selection)
 	}
 
 	pub fn get_image(&self) -> Result<ImageData> {
 		let formats = [self.inner.atoms.PNG_MIME];
-		let bytes = self.inner.read(&formats)?.bytes;
+		let bytes = self.inner.read(&formats, LinuxClipboardKind::Clipboard)?.bytes;
 
 		let cursor = std::io::Cursor::new(&bytes);
 		let mut reader = image::io::Reader::new(cursor);
@@ -813,7 +870,7 @@ impl X11ClipboardContext {
 	pub fn set_image(&self, image: ImageData) -> Result<()> {
 		let encoded = encode_as_png(&image)?;
 		let data = ClipboardData { bytes: encoded, format: self.inner.atoms.PNG_MIME };
-		self.inner.write(data)
+		self.inner.write(data, LinuxClipboardKind::Clipboard)
 	}
 }
 

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -835,9 +835,7 @@ impl X11ClipboardContext {
 	}
 
 	pub fn set_text(&self, message: String) -> Result<()> {
-		let data =
-			ClipboardData { bytes: message.into_bytes(), format: self.inner.atoms.UTF8_STRING };
-		self.inner.write(data, LinuxClipboardKind::Clipboard)
+		self.set_text_with_clipboard(message, LinuxClipboardKind::Clipboard)
 	}
 
 	pub(crate) fn set_text_with_clipboard(


### PR DESCRIPTION
On linux, we have multiple different clipboards (3 on X11, 2 on Wayland). This PR exposes the ability to operate on the alternate clipboards without altering the cross platform API (utilizing an extension trait).

I look forward to hearing what you think of these changes :grinning:.

Closes #16