### PR TITLE
Make image data functionality an optional feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,17 +39,17 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose
+          args: --verbose --no-default-features
       - name: Run `cargo clippy` with `image-data` feature
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose --features image-data
+          args: --verbose --no-default-features --features image-data
       - name: Run `cargo clippy` with `wayland-data-control` feature
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose --features wayland-data-control
+          args: --verbose --no-default-features --features wayland-data-control
       - name: Run `cargo clippy` with all features
         uses: actions-rs/cargo@v1
         with:
@@ -74,15 +74,19 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --no-default-features
       - name: Run tests with `image-data` feature
         uses: actions-rs/cargo@v1
         with:
-          command: test --features image-data
+          command: test
+          args: --no-default-features --features image-data
       - name: Run tests with `wayland-data-control` feature
         uses: actions-rs/cargo@v1
         with:
-          command: test --features wayland-data-control
+          command: test
+          args: --no-default-features --features wayland-data-control
       - name: Run tests with all features
         uses: actions-rs/cargo@v1
         with:
-          command: test --all-features
+          command: test
+          args: --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,10 @@ jobs:
 
   clippy:
     needs: rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - uses: actions-rs/toolchain@v1
         with:
@@ -32,7 +35,22 @@ jobs:
           override: true
           components: clippy
       - uses: actions/checkout@v2
-      - name: Run `cargo clippy`
+      - name: Run `cargo clippy` with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose
+      - name: Run `cargo clippy` with `image-data` feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose --features image-data
+      - name: Run `cargo clippy` with `wayland-data-control` feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose --features wayland-data-control
+      - name: Run `cargo clippy` with all features
         uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -52,8 +70,19 @@ jobs:
           override: true
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run tests
+      - name: Run tests with no features
         uses: actions-rs/cargo@v1
         with:
           command: test
-
+      - name: Run tests with `image-data` feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: test --features image-data
+      - name: Run tests with `wayland-data-control` feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: test --features wayland-data-control
+      - name: Run tests with all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["clipboard", "image"]
 edition = "2018"
 
 [features]
+image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
@@ -22,28 +23,33 @@ env_logger = "0.8.3"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = [
     "basetsd",
-    "minwindef",
     "stringapiset",
     "winuser",
     "winbase",
-    "wingdi",
-    "winnt",
 ]}
 scopeguard = "1.1.0"
 clipboard-win = "4.0"
-image = { version = "0.23.12", default-features = false, features = ["bmp"] }
+image = { version = "0.23.12", optional = true, default-features = false, features = ["bmp"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"
-core-graphics = "0.21"
-image = { version = "0.23", default-features = false, features = ["tiff"] }
+core-graphics = { version = "0.21", optional = true }
+image = { version = "0.23", optional = true, default-features = false, features = ["tiff"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 log = "0.4"
 x11rb = { version = "0.8" }
 wl-clipboard-rs = { version = "0.4.1", optional = true }
-image = { version = "0.23.9", default-features = false, features = ["png"] }
+image = { version = "0.23.9", optional = true, default-features = false, features = ["png"] }
 parking_lot = "0.11"
 once_cell = "1.7"
+
+[[example]]
+name = "get_image"
+required-features = ["image-data"]
+
+[[example]]
+name = "set_image"
+required-features = ["image-data"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["clipboard", "image"]
 edition = "2018"
 
 [features]
+default = ["image-data"]
 image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
 wayland-data-control = ["wl-clipboard-rs"]
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,6 +8,7 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
+#[cfg(feature = "image-data")]
 use std::borrow::Cow;
 use thiserror::Error;
 
@@ -97,6 +98,7 @@ impl std::fmt::Debug for Error {
 ///     bytes: Cow::from(bytes.as_ref())
 /// };
 /// ```
+#[cfg(feature = "image-data")]
 #[derive(Debug, Clone)]
 pub struct ImageData<'a> {
 	pub width: usize,
@@ -104,10 +106,11 @@ pub struct ImageData<'a> {
 	pub bytes: Cow<'a, [u8]>,
 }
 
+#[cfg(feature = "image-data")]
 impl<'a> ImageData<'a> {
 	/// Returns a the bytes field in a way that it's guaranteed to be owned.
 	/// It moves the bytes if they are already owned and clones them if they are borrowed.
-	pub fn into_owned_bytes(self) -> std::borrow::Cow<'static, [u8]> {
+	pub fn into_owned_bytes(self) -> Cow<'static, [u8]> {
 		self.bytes.into_owned().into()
 	}
 

--- a/src/common_linux.rs
+++ b/src/common_linux.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "image-data")]
 use std::{cell::RefCell, rc::Rc};
 
 #[cfg(feature = "wayland-data-control")]
@@ -5,12 +6,15 @@ use crate::wayland_data_control_clipboard::WaylandDataControlClipboardContext;
 #[cfg(feature = "wayland-data-control")]
 use log::{info, warn};
 
-use crate::{x11_clipboard::X11ClipboardContext, Error, ImageData};
+#[cfg(feature = "image-data")]
+use crate::ImageData;
+use crate::{x11_clipboard::X11ClipboardContext, Error};
 
 pub fn into_unknown<E: std::fmt::Display>(error: E) -> Error {
 	Error::Unknown { description: format!("{}", error) }
 }
 
+#[cfg(feature = "image-data")]
 pub fn encode_as_png(image: &ImageData) -> Result<Vec<u8>, Error> {
 	/// This is a workaround for the PNGEncoder not having a `into_inner` like function
 	/// which would allow us to take back our Vec after the encoder finished encoding.
@@ -105,6 +109,7 @@ impl LinuxClipboard {
 	/// Any image data placed on the clipboard with `set_image` will be possible read back, using
 	/// this function. However it's of not guaranteed that an image placed on the clipboard by any
 	/// other application will be of a supported format.
+	#[cfg(feature = "image-data")]
 	pub fn get_image(&mut self) -> Result<ImageData, Error> {
 		match self {
 			Self::X11(cb) => cb.get_image(),
@@ -121,6 +126,7 @@ impl LinuxClipboard {
 	/// - On macOS: `NSImage` object
 	/// - On Linux: PNG, under the atom `image/png`
 	/// - On Windows: In order of priority `CF_DIB` and `CF_BITMAP`
+	#[cfg(feature = "image-data")]
 	pub fn set_image(&mut self, image: ImageData) -> Result<(), Error> {
 		match self {
 			Self::X11(cb) => cb.set_image(image),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,10 @@ and conditions of the chosen license apply to this file.
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
-#[cfg(windows)]
-extern crate clipboard_win;
-#[cfg(windows)]
-extern crate image;
-
 mod common;
-pub use common::{Error, ImageData};
+pub use common::Error;
+#[cfg(feature = "image-data")]
+pub use common::ImageData;
 
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),))]
 pub(crate) mod common_linux;
@@ -83,6 +80,7 @@ impl Clipboard {
 	/// Any image data placed on the clipboard with `set_image` will be possible read back, using
 	/// this function. However it's of not guaranteed that an image placed on the clipboard by any
 	/// other application will be of a supported format.
+	#[cfg(feature = "image-data")]
 	pub fn get_image(&mut self) -> Result<ImageData, Error> {
 		self.platform.get_image()
 	}
@@ -94,6 +92,7 @@ impl Clipboard {
 	/// - On macOS: `NSImage` object
 	/// - On Linux: PNG, under the atom `image/png`
 	/// - On Windows: In order of priority `CF_DIB` and `CF_BITMAP`
+	#[cfg(feature = "image-data")]
 	pub fn set_image(&mut self, image: ImageData) -> Result<(), Error> {
 		self.platform.set_image(image)
 	}
@@ -130,6 +129,7 @@ fn all_tests() {
 		ctx.set_text(text.to_owned()).unwrap();
 		assert_eq!(ctx.get_text().unwrap(), text);
 	}
+	#[cfg(feature = "image-data")]
 	{
 		let mut ctx = Clipboard::new().unwrap();
 		#[rustfmt::skip]

--- a/src/wayland_data_control_clipboard.rs
+++ b/src/wayland_data_control_clipboard.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read};
+use std::io::Read;
 
 use wl_clipboard_rs::{
 	copy::{Options, Source},
@@ -6,12 +6,12 @@ use wl_clipboard_rs::{
 	utils::is_primary_selection_supported,
 };
 
-use crate::{
-	common::{Error, ImageData},
-	common_linux::{encode_as_png, into_unknown},
-};
+use crate::{common::Error, common_linux::into_unknown};
+#[cfg(feature = "image-data")]
+use crate::{common::ImageData, common_linux::encode_as_png};
 
-static MIME_PNG: &str = "image/png";
+#[cfg(feature = "image-data")]
+const MIME_PNG: &str = "image/png";
 
 pub struct WaylandDataControlClipboardContext {}
 
@@ -51,7 +51,10 @@ impl WaylandDataControlClipboardContext {
 		Ok(())
 	}
 
+	#[cfg(feature = "image-data")]
 	pub fn get_image(&mut self) -> Result<ImageData, Error> {
+		use std::io::Cursor;
+
 		use wl_clipboard_rs::paste::MimeType;
 		let result =
 			get_contents(ClipboardType::Regular, Seat::Unspecified, MimeType::Specific(MIME_PNG));
@@ -85,6 +88,7 @@ impl WaylandDataControlClipboardContext {
 		}
 	}
 
+	#[cfg(feature = "image-data")]
 	pub fn set_image(&mut self, image: ImageData) -> Result<(), Error> {
 		use wl_clipboard_rs::copy::MimeType;
 

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -43,10 +43,9 @@ use x11rb::{
 	COPY_DEPTH_FROM_PARENT, COPY_FROM_PARENT, NONE,
 };
 
-use crate::{
-	common_linux::{encode_as_png, into_unknown},
-	Error, ImageData,
-};
+#[cfg(feature = "image-data")]
+use crate::{common_linux::encode_as_png, ImageData};
+use crate::{common_linux::into_unknown, Error};
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -793,6 +792,7 @@ impl X11ClipboardContext {
 		self.inner.write(data)
 	}
 
+	#[cfg(feature = "image-data")]
 	pub fn get_image(&self) -> Result<ImageData> {
 		let formats = [self.inner.atoms.PNG_MIME];
 		let bytes = self.inner.read(&formats)?.bytes;
@@ -810,6 +810,7 @@ impl X11ClipboardContext {
 		Ok(image_data)
 	}
 
+	#[cfg(feature = "image-data")]
 	pub fn set_image(&self, image: ImageData) -> Result<()> {
 		let encoded = encode_as_png(&image)?;
 		let data = ClipboardData { bytes: encoded, format: self.inner.atoms.PNG_MIME };


### PR DESCRIPTION
Currently the `image` crate and platform specific additional crates & features are always compiled even if the image related feature is not used. In my current project I have exactly this case where I only need to set text for the clipboard and don't really care about images (although that feature is really neat!).

This PR adds a new `image-data` feature that will only enable the image related functionality when activated, thus greatly reducing the amount of dependencies and therefore build time when that feature isn't needed.

This would currently be a breaking API change as it's now disabled by default and image features would disappear for upgrading users until they add the feature flag. If you like these changes but would like to make it non-breaking, I can add the `image-data` feature to the `default` set of course 🙇‍♂️. 