### PR TITLE
Update x11rb to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ image = { version = "0.23", optional = true, default-features = false, features 
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 log = "0.4"
-x11rb = { version = "0.8" }
+x11rb = { version = "0.9" }
 wl-clipboard-rs = { version = "0.4.1", optional = true }
 image = { version = "0.23.9", optional = true, default-features = false, features = ["png"] }
 parking_lot = "0.11"


### PR DESCRIPTION
This PR updates the `x11-rb` dependency to the latest version. I ran `cargo check` locally and none of the few breaking changes in `0.9` seemed to affect `arboard`.